### PR TITLE
Serverdata fix

### DIFF
--- a/db.json
+++ b/db.json
@@ -27,6 +27,1044 @@
       "isActive": false
     }
   ],
+  "priceCompareMarkets": [
+    {
+      "id": "pc1",
+      "name": "이마트 성수점",
+      "distance": "0.3km",
+      "walkTime": "4분",
+      "rating": 4.5,
+      "address": "서울시 성동구 성수동",
+      "phone": "02-1234-5678",
+      "operatingHours": "10:00 - 22:00",
+      "lastUpdated": "2024.01.15 14:30"
+    },
+    {
+      "id": "pc2",
+      "name": "롯데마트 건대점",
+      "distance": "0.8km",
+      "walkTime": "10분",
+      "rating": 4.2,
+      "address": "서울시 광진구 건국대학교",
+      "phone": "02-2345-6789",
+      "operatingHours": "10:00 - 23:00",
+      "lastUpdated": "2024.01.15 12:00"
+    },
+    {
+      "id": "pc3",
+      "name": "GS25 성수역점",
+      "distance": "0.2km",
+      "walkTime": "2분",
+      "rating": 3.8,
+      "address": "서울시 성동구 성수역",
+      "phone": "02-3456-7890",
+      "operatingHours": "24시간",
+      "lastUpdated": "2024.01.15 16:45"
+    },
+    {
+      "id": "pc4",
+      "name": "홈플러스 왕십리점",
+      "distance": "1.2km",
+      "walkTime": "15분",
+      "rating": 4.3,
+      "address": "서울시 성동구 왕십리",
+      "phone": "02-4567-8901",
+      "operatingHours": "10:00 - 24:00",
+      "lastUpdated": "2024.01.15 13:20"
+    },
+    {
+      "id": "pc5",
+      "name": "세븐일레븐 성수점",
+      "distance": "0.1km",
+      "walkTime": "1분",
+      "rating": 4.0,
+      "address": "서울시 성동구 성수동1가",
+      "phone": "02-5678-9012",
+      "operatingHours": "24시간",
+      "lastUpdated": "2024.01.15 15:10"
+    },
+    {
+      "id": "pc6",
+      "name": "코스트코 양평점",
+      "distance": "2.5km",
+      "walkTime": "30분",
+      "rating": 4.6,
+      "address": "서울시 영등포구 양평동",
+      "phone": "02-6789-0123",
+      "operatingHours": "10:00 - 22:00",
+      "lastUpdated": "2024.01.15 11:00"
+    },
+    {
+      "id": "pc7",
+      "name": "하나로마트 성동점",
+      "distance": "1.8km",
+      "walkTime": "22분",
+      "rating": 4.1,
+      "address": "서울시 성동구 용답동",
+      "phone": "02-7890-1234",
+      "operatingHours": "09:00 - 21:00",
+      "lastUpdated": "2024.01.15 14:00"
+    },
+    {
+      "id": "pc8",
+      "name": "CU 건대입구역점",
+      "distance": "0.9km",
+      "walkTime": "11분",
+      "rating": 3.9,
+      "address": "서울시 광진구 건대입구역",
+      "phone": "02-8901-2345",
+      "operatingHours": "24시간",
+      "lastUpdated": "2024.01.15 17:30"
+    }
+  ],
+  "priceCompareProducts": [
+    {
+      "id": "pcp1",
+      "name": "토마토",
+      "marketId": "pc1",
+      "price": 2500,
+      "originalPrice": 3000,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp2",
+      "name": "토마토",
+      "marketId": "pc2",
+      "price": 2800,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp3",
+      "name": "토마토",
+      "marketId": "pc3",
+      "price": 3200,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp4",
+      "name": "토마토",
+      "marketId": "pc4",
+      "price": 2400,
+      "originalPrice": 2600,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp5",
+      "name": "토마토",
+      "marketId": "pc5",
+      "price": 3100,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp6",
+      "name": "당근",
+      "marketId": "pc1",
+      "price": 2000,
+      "originalPrice": 2500,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp7",
+      "name": "당근",
+      "marketId": "pc2",
+      "price": 2300,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp8",
+      "name": "당근",
+      "marketId": "pc3",
+      "price": 2800,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp9",
+      "name": "당근",
+      "marketId": "pc4",
+      "price": 1900,
+      "originalPrice": 2200,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp10",
+      "name": "당근",
+      "marketId": "pc5",
+      "price": 2600,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp11",
+      "name": "오렌지",
+      "marketId": "pc1",
+      "price": 4500,
+      "originalPrice": 5000,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp12",
+      "name": "오렌지",
+      "marketId": "pc2",
+      "price": 4800,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp13",
+      "name": "오렌지",
+      "marketId": "pc3",
+      "price": 5200,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp14",
+      "name": "오렌지",
+      "marketId": "pc4",
+      "price": 4300,
+      "originalPrice": 4600,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp15",
+      "name": "오렌지",
+      "marketId": "pc5",
+      "price": 4900,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp16",
+      "name": "딸기",
+      "marketId": "pc1",
+      "price": 8500,
+      "originalPrice": 9000,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp17",
+      "name": "딸기",
+      "marketId": "pc2",
+      "price": 8800,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp18",
+      "name": "딸기",
+      "marketId": "pc3",
+      "price": 9200,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp19",
+      "name": "딸기",
+      "marketId": "pc4",
+      "price": 8200,
+      "originalPrice": 8700,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp20",
+      "name": "딸기",
+      "marketId": "pc5",
+      "price": 8900,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp21",
+      "name": "포도",
+      "marketId": "pc1",
+      "price": 6500,
+      "originalPrice": 7000,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp22",
+      "name": "포도",
+      "marketId": "pc2",
+      "price": 6800,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp23",
+      "name": "포도",
+      "marketId": "pc3",
+      "price": 7200,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp24",
+      "name": "포도",
+      "marketId": "pc4",
+      "price": 6300,
+      "originalPrice": 6600,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp25",
+      "name": "포도",
+      "marketId": "pc5",
+      "price": 6900,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp26",
+      "name": "배추",
+      "marketId": "pc1",
+      "price": 2500,
+      "originalPrice": 3000,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp27",
+      "name": "배추",
+      "marketId": "pc2",
+      "price": 2800,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp28",
+      "name": "배추",
+      "marketId": "pc3",
+      "price": 3200,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp29",
+      "name": "배추",
+      "marketId": "pc4",
+      "price": 2400,
+      "originalPrice": 2700,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp30",
+      "name": "배추",
+      "marketId": "pc5",
+      "price": 2900,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp31",
+      "name": "시금치",
+      "marketId": "pc1",
+      "price": 1500,
+      "originalPrice": 1800,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp32",
+      "name": "시금치",
+      "marketId": "pc2",
+      "price": 1700,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp33",
+      "name": "시금치",
+      "marketId": "pc3",
+      "price": 1900,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp34",
+      "name": "시금치",
+      "marketId": "pc4",
+      "price": 1400,
+      "originalPrice": 1600,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp35",
+      "name": "시금치",
+      "marketId": "pc5",
+      "price": 1800,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp36",
+      "name": "오이",
+      "marketId": "pc1",
+      "price": 2200,
+      "originalPrice": 2500,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp37",
+      "name": "오이",
+      "marketId": "pc2",
+      "price": 2400,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp38",
+      "name": "오이",
+      "marketId": "pc3",
+      "price": 2700,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp39",
+      "name": "오이",
+      "marketId": "pc4",
+      "price": 2100,
+      "originalPrice": 2300,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp40",
+      "name": "오이",
+      "marketId": "pc5",
+      "price": 2600,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp41",
+      "name": "삼겹살",
+      "marketId": "pc1",
+      "price": 15000,
+      "originalPrice": 16000,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp42",
+      "name": "삼겹살",
+      "marketId": "pc2",
+      "price": 15500,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp43",
+      "name": "삼겹살",
+      "marketId": "pc3",
+      "price": 16200,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp44",
+      "name": "삼겹살",
+      "marketId": "pc4",
+      "price": 14800,
+      "originalPrice": 15300,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp45",
+      "name": "삼겹살",
+      "marketId": "pc5",
+      "price": 15800,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp46",
+      "name": "닭가슴살",
+      "marketId": "pc1",
+      "price": 6500,
+      "originalPrice": 7000,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp47",
+      "name": "닭가슴살",
+      "marketId": "pc2",
+      "price": 6800,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp48",
+      "name": "닭가슴살",
+      "marketId": "pc3",
+      "price": 7200,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp49",
+      "name": "닭가슴살",
+      "marketId": "pc4",
+      "price": 6300,
+      "originalPrice": 6600,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp50",
+      "name": "닭가슴살",
+      "marketId": "pc5",
+      "price": 6900,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp51",
+      "name": "연어",
+      "marketId": "pc1",
+      "price": 12000,
+      "originalPrice": 13000,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp52",
+      "name": "연어",
+      "marketId": "pc2",
+      "price": 12500,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp53",
+      "name": "연어",
+      "marketId": "pc3",
+      "price": 13200,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp54",
+      "name": "연어",
+      "marketId": "pc4",
+      "price": 11800,
+      "originalPrice": 12300,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp55",
+      "name": "연어",
+      "marketId": "pc5",
+      "price": 12800,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp56",
+      "name": "우유",
+      "marketId": "pc1",
+      "price": 2800,
+      "originalPrice": 3000,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp57",
+      "name": "우유",
+      "marketId": "pc2",
+      "price": 2900,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp58",
+      "name": "우유",
+      "marketId": "pc3",
+      "price": 3100,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp59",
+      "name": "우유",
+      "marketId": "pc4",
+      "price": 2700,
+      "originalPrice": 2900,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp60",
+      "name": "우유",
+      "marketId": "pc5",
+      "price": 3000,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp61",
+      "name": "라면",
+      "marketId": "pc1",
+      "price": 3500,
+      "originalPrice": 4000,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp62",
+      "name": "라면",
+      "marketId": "pc2",
+      "price": 3800,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp63",
+      "name": "라면",
+      "marketId": "pc3",
+      "price": 4200,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp64",
+      "name": "라면",
+      "marketId": "pc4",
+      "price": 3400,
+      "originalPrice": 3700,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp65",
+      "name": "라면",
+      "marketId": "pc5",
+      "price": 3900,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp66",
+      "name": "토마토",
+      "marketId": "pc6",
+      "price": 2200,
+      "originalPrice": 2800,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp67",
+      "name": "토마토",
+      "marketId": "pc7",
+      "price": 2700,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp68",
+      "name": "토마토",
+      "marketId": "pc8",
+      "price": 3000,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp69",
+      "name": "오렌지",
+      "marketId": "pc6",
+      "price": 4100,
+      "originalPrice": 4400,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp70",
+      "name": "오렌지",
+      "marketId": "pc7",
+      "price": 4600,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp71",
+      "name": "오렌지",
+      "marketId": "pc8",
+      "price": 5100,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp72",
+      "name": "삼겹살",
+      "marketId": "pc6",
+      "price": 14500,
+      "originalPrice": 15200,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp73",
+      "name": "삼겹살",
+      "marketId": "pc7",
+      "price": 15200,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp74",
+      "name": "삼겹살",
+      "marketId": "pc8",
+      "price": 16000,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp75",
+      "name": "우유",
+      "marketId": "pc6",
+      "price": 2600,
+      "originalPrice": 2800,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp76",
+      "name": "우유",
+      "marketId": "pc7",
+      "price": 2850,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp77",
+      "name": "우유",
+      "marketId": "pc8",
+      "price": 3050,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp78",
+      "name": "배추",
+      "marketId": "pc6",
+      "price": 2300,
+      "originalPrice": 2600,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp79",
+      "name": "배추",
+      "marketId": "pc7",
+      "price": 2600,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp80",
+      "name": "배추",
+      "marketId": "pc8",
+      "price": 3000,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp81",
+      "name": "딸기",
+      "marketId": "pc6",
+      "price": 8000,
+      "originalPrice": 8500,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp82",
+      "name": "딸기",
+      "marketId": "pc7",
+      "price": 8600,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp83",
+      "name": "딸기",
+      "marketId": "pc8",
+      "price": 9100,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp84",
+      "name": "연어",
+      "marketId": "pc6",
+      "price": 11500,
+      "originalPrice": 12000,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp85",
+      "name": "연어",
+      "marketId": "pc7",
+      "price": 12200,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp86",
+      "name": "연어",
+      "marketId": "pc8",
+      "price": 13000,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp87",
+      "name": "라면",
+      "marketId": "pc6",
+      "price": 3300,
+      "originalPrice": 3600,
+      "isOnSale": true
+    },
+    {
+      "id": "pcp88",
+      "name": "라면",
+      "marketId": "pc7",
+      "price": 3750,
+      "originalPrice": null,
+      "isOnSale": false
+    },
+    {
+      "id": "pcp89",
+      "name": "라면",
+      "marketId": "pc8",
+      "price": 4100,
+      "originalPrice": null,
+      "isOnSale": false
+    }
+  ],
+  "categories": [
+    {
+      "id": "beverages",
+      "name": "음료류",
+      "emoji": "🥤",
+      "totalItems": 6
+    },
+    {
+      "id": "meat-seafood",
+      "name": "육류 및 수산물",
+      "emoji": "🥩",
+      "totalItems": 16
+    },
+    {
+      "id": "grains-noodles",
+      "name": "곡류 및 면류",
+      "emoji": "🌾",
+      "totalItems": 7
+    },
+    {
+      "id": "vegetables",
+      "name": "채소류",
+      "emoji": "🥕",
+      "totalItems": 18
+    },
+    {
+      "id": "fruits",
+      "name": "과일류",
+      "emoji": "🍎",
+      "totalItems": 11
+    },
+    {
+      "id": "processed-foods",
+      "name": "가공식품 및 간편식",
+      "emoji": "🍞",
+      "totalItems": 4
+    },
+    {
+      "id": "seasonings",
+      "name": "조미료 및 소스류",
+      "emoji": "🧂",
+      "totalItems": 12
+    },
+    {
+      "id": "household-items",
+      "name": "생활용품",
+      "emoji": "🧴",
+      "totalItems": 6
+    }
+  ],
+  "categoryItems": [
+    {
+      "id": "soda-1-5l",
+      "name": "사이다",
+      "unit": "1.5L",
+      "categoryId": "beverages",
+      "subcategoryId": "beverages-all"
+    },
+    {
+      "id": "cola-1-5l",
+      "name": "콜라",
+      "unit": "1.5L",
+      "categoryId": "beverages",
+      "subcategoryId": "beverages-all"
+    },
+    {
+      "id": "carrot-1kg",
+      "name": "당근",
+      "unit": "1kg",
+      "categoryId": "vegetables",
+      "subcategoryId": "root-vegetables"
+    },
+    {
+      "id": "tomato-1kg",
+      "name": "토마토",
+      "unit": "1kg",
+      "categoryId": "vegetables",
+      "subcategoryId": "other-vegetables"
+    },
+    {
+      "id": "onion-net",
+      "name": "양파",
+      "unit": "1망",
+      "categoryId": "vegetables",
+      "subcategoryId": "root-vegetables"
+    },
+    {
+      "id": "banana-1bunch",
+      "name": "바나나",
+      "unit": "1송이",
+      "categoryId": "fruits",
+      "subcategoryId": "fruits-all"
+    },
+    {
+      "id": "apple-busa-1",
+      "name": "사과(부사)",
+      "unit": "1개",
+      "categoryId": "fruits",
+      "subcategoryId": "fruits-all"
+    },
+    {
+      "id": "orange-1kg",
+      "name": "오렌지",
+      "unit": "1kg",
+      "categoryId": "fruits",
+      "subcategoryId": "fruits-all"
+    },
+    {
+      "id": "strawberry-500g",
+      "name": "딸기",
+      "unit": "500g",
+      "categoryId": "fruits",
+      "subcategoryId": "fruits-all"
+    },
+    {
+      "id": "grape-1bunch",
+      "name": "포도",
+      "unit": "1송이",
+      "categoryId": "fruits",
+      "subcategoryId": "fruits-all"
+    },
+    {
+      "id": "watermelon-1ea",
+      "name": "수박",
+      "unit": "1개",
+      "categoryId": "fruits",
+      "subcategoryId": "fruits-all"
+    },
+    {
+      "id": "cabbage-1ea",
+      "name": "배추",
+      "unit": "1포기",
+      "categoryId": "vegetables",
+      "subcategoryId": "leafy-vegetables"
+    },
+    {
+      "id": "spinach-300g",
+      "name": "시금치",
+      "unit": "300g",
+      "categoryId": "vegetables",
+      "subcategoryId": "leafy-vegetables"
+    },
+    {
+      "id": "lettuce-1ea",
+      "name": "상추",
+      "unit": "1포기",
+      "categoryId": "vegetables",
+      "subcategoryId": "leafy-vegetables"
+    },
+    {
+      "id": "cucumber-3ea",
+      "name": "오이",
+      "unit": "3개",
+      "categoryId": "vegetables",
+      "subcategoryId": "other-vegetables"
+    },
+    {
+      "id": "bell-pepper-3ea",
+      "name": "파프리카",
+      "unit": "3개",
+      "categoryId": "vegetables",
+      "subcategoryId": "other-vegetables"
+    },
+    {
+      "id": "beef-sirloin-500g",
+      "name": "한우등심",
+      "unit": "500g",
+      "categoryId": "meat-seafood",
+      "subcategoryId": "meat"
+    },
+    {
+      "id": "pork-belly-500g",
+      "name": "삼겹살",
+      "unit": "500g",
+      "categoryId": "meat-seafood",
+      "subcategoryId": "meat"
+    },
+    {
+      "id": "chicken-breast-500g",
+      "name": "닭가슴살",
+      "unit": "500g",
+      "categoryId": "meat-seafood",
+      "subcategoryId": "meat"
+    },
+    {
+      "id": "salmon-300g",
+      "name": "연어",
+      "unit": "300g",
+      "categoryId": "meat-seafood",
+      "subcategoryId": "seafood"
+    },
+    {
+      "id": "mackerel-2ea",
+      "name": "고등어",
+      "unit": "2마리",
+      "categoryId": "meat-seafood",
+      "subcategoryId": "seafood"
+    },
+    {
+      "id": "rice-10kg",
+      "name": "쌀",
+      "unit": "10kg",
+      "categoryId": "grains-noodles",
+      "subcategoryId": "grains"
+    },
+    {
+      "id": "ramen-4ea",
+      "name": "라면",
+      "unit": "4개입",
+      "categoryId": "grains-noodles",
+      "subcategoryId": "noodles"
+    },
+    {
+      "id": "milk-1l",
+      "name": "우유",
+      "unit": "1L",
+      "categoryId": "dairy",
+      "subcategoryId": "dairy-all"
+    },
+    {
+      "id": "yogurt-4pack",
+      "name": "요거트",
+      "unit": "4개입",
+      "categoryId": "dairy",
+      "subcategoryId": "dairy-all"
+    },
+    {
+      "id": "orange-juice-1l",
+      "name": "오렌지주스",
+      "unit": "1L",
+      "categoryId": "beverages",
+      "subcategoryId": "beverages-all"
+    }
+  ],
   "recommendations": [
     {
       "id": "1",

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -1,16 +1,34 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import BottomNavigation from '@/components/layout/BottomNavigation';
 import PageHeader from '@/components/layout/PageHeader';
 import CategoryCard from '@/components/category/CategoryCard';
 import CategoryDetail from '@/components/category/CategoryDetail';
-import { categoryData, Category } from '@/lib/data/categories';
+import { categoryAPI } from '@/lib/api/client';
+import { Category } from '@/lib/api/types';
 
 export default function CategoryPage() {
   const [selectedCategory, setSelectedCategory] = useState<Category | null>(
     null
   );
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchCategories = async () => {
+      try {
+        const data = await categoryAPI.getCategories();
+        setCategories(data);
+      } catch (error) {
+        console.error('카테고리 데이터 로드 실패:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchCategories();
+  }, []);
 
   const handleCategoryClick = (category: Category) => {
     setSelectedCategory(category);
@@ -36,23 +54,28 @@ export default function CategoryPage() {
         title="카테고리"
         rightElement={
           <div className="text-sm text-gray-600">
-            총 {categoryData.reduce((sum, cat) => sum + cat.totalItems, 0)}개
-            품목
+            총 {categories.reduce((sum, cat) => sum + cat.totalItems, 0)}개 품목
           </div>
         }
       />
 
       {/* 카테고리 그리드 */}
       <div className="flex-1 p-4">
-        <div className="grid grid-cols-2 gap-4">
-          {categoryData.map((category) => (
-            <CategoryCard
-              key={category.id}
-              category={category}
-              onClick={handleCategoryClick}
-            />
-          ))}
-        </div>
+        {isLoading ? (
+          <div className="flex items-center justify-center h-64">
+            <div className="animate-spin rounded-full h-12 w-12 border-2 border-primary-500 border-t-transparent"></div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-4">
+            {categories.map((category) => (
+              <CategoryCard
+                key={category.id}
+                category={category}
+                onClick={handleCategoryClick}
+              />
+            ))}
+          </div>
+        )}
       </div>
 
       {/* 하단 네비게이션 */}

--- a/src/app/scan/page.tsx
+++ b/src/app/scan/page.tsx
@@ -39,8 +39,8 @@ export default function Scan() {
 
   // 이미지 전처리 함수
   const preprocessImage = async (imageData: string): Promise<string> => {
-    return new Promise((resolve) => {
-      const img = new HTMLImageElement();
+    return new Promise((resolve, reject) => {
+      const img = document.createElement('img') as HTMLImageElement;
       img.onload = () => {
         const canvas = document.createElement('canvas');
         const ctx = canvas.getContext('2d');
@@ -89,6 +89,14 @@ export default function Scan() {
           resolve(imageData);
         }
       };
+
+      img.onerror = () => {
+        console.error('이미지 로딩 오류');
+        reject(new Error('이미지 로딩에 실패했습니다.'));
+      };
+
+      // CORS 문제 방지
+      img.crossOrigin = 'anonymous';
       img.src = imageData;
     });
   };
@@ -135,7 +143,13 @@ export default function Scan() {
       }
 
       // 이미지 전처리
-      const processedImage = await preprocessImage(imageData);
+      let processedImage;
+      try {
+        processedImage = await preprocessImage(imageData);
+      } catch (preprocessError) {
+        console.error('이미지 전처리 오류:', preprocessError);
+        processedImage = imageData; // 전처리 실패 시 원본 이미지 사용
+      }
 
       // Tesseract.js를 사용한 OCR 처리
       const result = await Tesseract.recognize(processedImage, 'kor+eng', {

--- a/src/components/category/CategoryCard.tsx
+++ b/src/components/category/CategoryCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Category } from '@/lib/data/categories';
+import { Category } from '@/lib/api/types';
 
 interface CategoryCardProps {
   category: Category;
@@ -22,9 +22,9 @@ export default function CategoryCard({ category, onClick }: CategoryCardProps) {
       </div>
       <h3 className="font-semibold text-gray-900 text-lg">{category.name}</h3>
       <p className="text-sm text-gray-600 mt-1">
-        {category.subcategories.length > 1
-          ? `${category.subcategories.length}개 세부 카테고리`
-          : '전체 품목 보기'}
+        {category.totalItems > 0
+          ? `${category.totalItems}개 품목`
+          : '품목 보기'}
       </p>
     </div>
   );

--- a/src/components/category/CategoryDetail.tsx
+++ b/src/components/category/CategoryDetail.tsx
@@ -1,20 +1,22 @@
 'use client';
 
-import React, { useState } from 'react';
-import { Category, SubCategory, CategoryItem } from '@/lib/data/categories';
+import React, { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Category as APICategory, CategoryItem } from '@/lib/api/types';
+import { categoryAPI } from '@/lib/api/client';
 import { IoChevronBack } from 'react-icons/io5';
 
 interface CategoryDetailProps {
-  category: Category;
+  category: APICategory;
   onBack: () => void;
 }
 
 interface ItemCardProps {
   item: CategoryItem;
-  onAddToCart?: (item: CategoryItem) => void;
+  onComparePrice?: (item: CategoryItem) => void;
 }
 
-function ItemCard({ item, onAddToCart }: ItemCardProps) {
+function ItemCard({ item, onComparePrice }: ItemCardProps) {
   return (
     <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-100">
       <div className="flex items-center justify-between">
@@ -23,10 +25,10 @@ function ItemCard({ item, onAddToCart }: ItemCardProps) {
           <p className="text-sm text-gray-600">{item.unit}</p>
         </div>
         <button
-          onClick={() => onAddToCart?.(item)}
+          onClick={() => onComparePrice?.(item)}
           className="bg-primary-500 text-white px-3 py-1.5 rounded-lg text-sm font-medium hover:bg-primary-600 transition-colors touch-feedback"
         >
-          장바구니
+          가격비교
         </button>
       </div>
     </div>
@@ -37,17 +39,28 @@ export default function CategoryDetail({
   category,
   onBack,
 }: CategoryDetailProps) {
-  const [selectedSubcategory, setSelectedSubcategory] = useState<string>(
-    category.subcategories[0]?.id || ''
-  );
+  const [categoryItems, setCategoryItems] = useState<CategoryItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const router = useRouter();
 
-  const currentSubcategory = category.subcategories.find(
-    (sub) => sub.id === selectedSubcategory
-  );
+  useEffect(() => {
+    const fetchCategoryItems = async () => {
+      try {
+        const data = await categoryAPI.getCategoryItems(category.id);
+        setCategoryItems(data);
+      } catch (error) {
+        console.error('카테고리 아이템 로드 실패:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
 
-  const handleAddToCart = (item: CategoryItem) => {
-    // TODO: 장바구니 추가 로직 구현
-    console.log('장바구니에 추가:', item);
+    fetchCategoryItems();
+  }, [category.id]);
+
+  const handleComparePrice = (item: CategoryItem) => {
+    // 가격 비교 페이지로 이동
+    router.push(`/scan/price-compare?item=${encodeURIComponent(item.name)}`);
   };
 
   return (
@@ -64,45 +77,30 @@ export default function CategoryDetail({
           <div className="text-2xl">{category.emoji}</div>
           <h1 className="text-xl font-bold text-gray-900">{category.name}</h1>
         </div>
-
-        {/* 서브카테고리 탭 */}
-        {category.subcategories.length > 1 && (
-          <div className="flex gap-2 overflow-x-auto">
-            {category.subcategories.map((sub) => (
-              <button
-                key={sub.id}
-                onClick={() => setSelectedSubcategory(sub.id)}
-                className={`px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap touch-feedback transition-colors ${
-                  selectedSubcategory === sub.id
-                    ? 'bg-primary-500 text-white'
-                    : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-                }`}
-              >
-                {sub.name}
-              </button>
-            ))}
-          </div>
-        )}
       </div>
 
       {/* 아이템 목록 */}
       <div className="flex-1 overflow-y-auto p-4">
-        {currentSubcategory && (
+        {isLoading ? (
+          <div className="flex items-center justify-center h-64">
+            <div className="animate-spin rounded-full h-12 w-12 border-2 border-primary-500 border-t-transparent"></div>
+          </div>
+        ) : (
           <div className="space-y-3">
             <div className="flex items-center justify-between mb-4">
               <h2 className="text-lg font-semibold text-gray-900">
-                {currentSubcategory.name}
+                {category.name} 상품
               </h2>
               <span className="text-sm text-gray-500">
-                {currentSubcategory.items.length}개 상품
+                {categoryItems.length}개 상품
               </span>
             </div>
 
-            {currentSubcategory.items.map((item) => (
+            {categoryItems.map((item) => (
               <ItemCard
                 key={item.id}
                 item={item}
-                onAddToCart={handleAddToCart}
+                onComparePrice={handleComparePrice}
               />
             ))}
           </div>

--- a/src/components/home/TopThreeProducts.tsx
+++ b/src/components/home/TopThreeProducts.tsx
@@ -1,14 +1,7 @@
 import Image from 'next/image';
 import { useEffect, useState, useCallback } from 'react';
-
-interface Product {
-  id: string;
-  emoji: string;
-  name: string;
-  savings: number;
-  marketId: number;
-  rank: number;
-}
+import { topProductAPI } from '@/lib/api/client';
+import { TopProduct } from '@/lib/api/types';
 
 interface TopThreeProductsProps {
   userName?: string;
@@ -19,7 +12,7 @@ export default function TopThreeProducts({
   userName = '사용자',
   marketId = 1, // 기본값으로 첫 번째 마켓 선택
 }: TopThreeProductsProps) {
-  const [products, setProducts] = useState<Product[]>([]);
+  const [products, setProducts] = useState<TopProduct[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -30,14 +23,7 @@ export default function TopThreeProducts({
 
       console.log('TopThreeProducts: Fetching data for marketId:', marketId);
 
-      const response = await fetch(
-        `http://localhost:3001/topProducts?marketId=${marketId}&_sort=rank&_order=asc`
-      );
-      if (!response.ok) {
-        throw new Error('데이터를 불러오는데 실패했습니다.');
-      }
-
-      const topProducts = await response.json();
+      const topProducts = await topProductAPI.getTopProducts(marketId);
       const limitedProducts = topProducts.slice(0, 3); // TOP 3만 가져오기
 
       console.log('TopThreeProducts: Fetched products:', limitedProducts);
@@ -59,7 +45,7 @@ export default function TopThreeProducts({
     fetchTopProducts();
   };
 
-  const handleProductClick = (productId: string) => {
+  const handleProductClick = (productId: number) => {
     console.log(`Product ${productId} clicked`);
     // 상품 상세 페이지로 이동하는 로직 구현
   };

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -73,3 +73,65 @@ export interface AddToFavoritesRequest {
   productId: number;
   userId: number;
 }
+
+// 가격 비교 관련 타입
+export interface PriceCompareMarket {
+  id: string;
+  name: string;
+  distance: string;
+  walkTime: string;
+  rating: number;
+  address: string;
+  phone: string;
+  operatingHours: string;
+  lastUpdated: string;
+}
+
+export interface PriceCompareProduct {
+  id: string;
+  name: string;
+  marketId: string;
+  price: number;
+  originalPrice?: number;
+  isOnSale: boolean;
+}
+
+export interface MarketInfo {
+  id: string;
+  name: string;
+  distance: string;
+  walkTime: string;
+  rating: number;
+  price: number;
+  originalPrice?: number;
+  isOnSale: boolean;
+  address: string;
+  phone: string;
+  operatingHours: string;
+  lastUpdated: string;
+}
+
+// 카테고리 관련 타입
+export interface Category {
+  id: string;
+  name: string;
+  emoji: string;
+  totalItems: number;
+}
+
+export interface CategoryItem {
+  id: string;
+  name: string;
+  unit: string;
+  categoryId: string;
+  subcategoryId: string;
+}
+
+// 장바구니 추가 요청 (마켓 정보 포함)
+export interface AddToCartWithMarketRequest {
+  productName: string;
+  marketName: string;
+  price: number;
+  userId: number;
+  quantity?: number;
+}


### PR DESCRIPTION
## 카테고리별 가격비교 데이터 확장 및 타입 오류 수정

- TopThreeProducts 컴포넌트 타입 오류 수정 (Product -> TopProduct)
- 카테고리 아이템 20개 추가 (과일, 채소, 육류, 유제품 등)
- 가격비교 마켓 3개 추가 (코스트코, 하나로마트, CU)
- 가격비교 상품 데이터 65개 추가 (총 8개 마켓 대응)
- 할인 상품 정보 및 가격 다양성 확보로 UX 개선"